### PR TITLE
Instrument compiler to add code that does timing measurements

### DIFF
--- a/bril-rs/brillvm/src/cli.rs
+++ b/bril-rs/brillvm/src/cli.rs
@@ -30,6 +30,9 @@ pub struct Cli {
     /// Arguments for the main function
     #[arg(action)]
     pub args: Vec<String>,
+
+    #[arg(action)]
+    pub add_timing: bool,
 }
 
 pub fn run(args: &Cli) -> String {
@@ -49,7 +52,7 @@ pub fn run(args: &Cli) -> String {
     let runtime_path = args.runtime.as_ref().map_or("rt.bc", |f| f);
     // create a module from the runtime library for functions like printing/parsing
     let runtime_module = Module::parse_bitcode_from_path(runtime_path, &context).unwrap();
-    let llvm_prog = create_module_from_program(&context, &prog, runtime_module);
+    let llvm_prog = create_module_from_program(&context, &prog, runtime_module, args.add_timing);
 
     //println!("{}", prog);
     //llvm_prog.print_to_file("tmp.ll").unwrap();

--- a/bril-rs/brillvm/src/llvm.rs
+++ b/bril-rs/brillvm/src/llvm.rs
@@ -1518,10 +1518,11 @@ pub fn create_module_from_program<'a>(
                         .try_as_basic_value()
                         .unwrap_left();
                     ticks_start_ref = Some(ticks_start);
-                    // make it always inline get_ticks_start
-                    let func = runtime_module.get_function(get_ticks_start).unwrap();
+                    // TODO I would like to inline get_ticks_start for less overhead
+                    // however, this results in segfaults for some reason
+                    /*let func = runtime_module.get_function(get_ticks_start).unwrap();
                     func.remove_enum_attribute(AttributeLoc::Function, 28);
-                    func.add_attribute(AttributeLoc::Function, context.create_enum_attribute(3, 1));
+                    func.add_attribute(AttributeLoc::Function, context.create_enum_attribute(3, 1));*/
                     // also assert the last instruction is a print
                     assert!(matches!(
                         instrs.last().unwrap().clone(),
@@ -1564,13 +1565,15 @@ pub fn create_module_from_program<'a>(
                         let get_ticks_end = "_bril_get_ticks_end";
                         #[cfg(target_arch = "aarch64")]
                         let get_ticks_end = "_bril_get_ticks";
-                        let func = runtime_module.get_function(get_ticks_end).unwrap();
+                        // TODO I would like to inline get_ticks_start for less overhead
+                        // however, this results in segfaults for some reason
+                        /*let func = runtime_module.get_function(get_ticks_end).unwrap();
                         // always inline get_ticks_end
                         func.remove_enum_attribute(AttributeLoc::Function, 28);
                         func.add_attribute(
                             AttributeLoc::Function,
                             context.create_enum_attribute(3, 1),
-                        );
+                        );*/
 
                         let ticks_end = builder
                             .build_call(

--- a/bril-rs/brillvm/src/llvm.rs
+++ b/bril-rs/brillvm/src/llvm.rs
@@ -1500,10 +1500,10 @@ pub fn create_module_from_program<'a>(
             if !instrs.is_empty() {
                 builder.position_at_end(block);
 
-                // in main, first start measuring time
                 // When we are in main, start measuring time
                 if llvm_func.get_name().to_str().unwrap() == "_main" {
                     let ticks_start_name = fresh.fresh_var();
+                    // get_ticks_start is used on x86 and get_ticks is used on arm
                     #[cfg(target_arch = "x86_64")]
                     let get_ticks_start = "_bril_get_ticks_start";
                     #[cfg(target_arch = "aarch64")]

--- a/bril-rs/brillvm/src/llvm.rs
+++ b/bril-rs/brillvm/src/llvm.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ffi::CStr};
 
 use inkwell::{
     attributes::{Attribute, AttributeLoc},
@@ -1491,6 +1491,8 @@ pub fn create_module_from_program<'a>(
         .collect(); // Important to collect, can't be done lazily because we need all functions to be loaded in before a call instruction of a function is processed.
 
     // Now actually build each function
+    let mut added_timing = false;
+    let mut ticks_start_ref = None;
     funcs
         .into_iter()
         .for_each(|(llvm_func, instrs, mut block, heap)| {
@@ -1500,10 +1502,90 @@ pub fn create_module_from_program<'a>(
             if !instrs.is_empty() {
                 builder.position_at_end(block);
 
+                // in main, first start measuring time
+                // When we are in main, start measuring time
+                if llvm_func.get_name().to_str().unwrap() == "_main" {
+                    let ticks_start_name = fresh.fresh_var();
+                    #[cfg(target_arch = "x86_64")]
+                    let get_ticks_start = "_bril_get_ticks_start";
+                    #[cfg(target_arch = "aarch64")]
+                    let get_ticks_start = "_bril_get_ticks";
+                    let ticks_start = builder
+                        .build_call(
+                            runtime_module.get_function(get_ticks_start).unwrap(),
+                            &[],
+                            &ticks_start_name,
+                        )
+                        .unwrap()
+                        .try_as_basic_value()
+                        .unwrap_left();
+                    ticks_start_ref = Some(ticks_start);
+                    // make it always inline get_ticks_start
+                    let func = runtime_module.get_function(get_ticks_start).unwrap();
+                    func.remove_enum_attribute(AttributeLoc::Function, 28);
+                    func.add_attribute(AttributeLoc::Function, context.create_enum_attribute(3, 1));
+                    // also assert the last instruction is a print
+                    assert!(matches!(
+                        instrs.last().unwrap().clone(),
+                        Code::Instruction(Instruction::Effect {
+                            op: EffectOps::Print,
+                            ..
+                        })
+                    ));
+                }
+
                 // Maps labels to llvm blocks for jumps
                 let mut block_map = HashMap::new();
                 let mut index = 0;
                 while index < instrs.len() {
+                    // for main, we expect the last instruction to be a print
+                    if llvm_func.get_name().to_str().unwrap() == "_main"
+                        && index == instrs.len() - 1
+                    {
+                        // measure cycles and print
+                        let ticks_end_name = fresh.fresh_var();
+                        #[cfg(target_arch = "x86_64")]
+                        let get_ticks_end = "_bril_get_ticks_end";
+                        #[cfg(target_arch = "aarch64")]
+                        let get_ticks_end = "_bril_get_ticks";
+                        let func = runtime_module.get_function(get_ticks_end).unwrap();
+                        // always inline get_ticks_end
+                        func.remove_enum_attribute(AttributeLoc::Function, 28);
+                        func.add_attribute(
+                            AttributeLoc::Function,
+                            context.create_enum_attribute(3, 1),
+                        );
+
+                        let ticks_end = builder
+                            .build_call(
+                                runtime_module.get_function(get_ticks_end).unwrap(),
+                                &[],
+                                &ticks_end_name,
+                            )
+                            .unwrap()
+                            .try_as_basic_value()
+                            .unwrap_left();
+
+                        // print out the different between the ticks
+                        let ticks_diff = fresh.fresh_var();
+                        let diff_val = builder
+                            .build_int_sub::<IntValue>(
+                                ticks_end.try_into().unwrap(),
+                                ticks_start_ref.unwrap().try_into().unwrap(),
+                                &ticks_diff,
+                            )
+                            .unwrap();
+
+                        // use bril_print_unsiged_int to print out the difference
+                        let print_ticks = runtime_module
+                            .get_function("_bril_eprintln_unsigned_int")
+                            .unwrap();
+                        builder
+                            .build_call(print_ticks, &[diff_val.into()], "print_ticks")
+                            .unwrap();
+                        added_timing = true;
+                    }
+
                     if is_terminating_instr(&last_instr)
                         && matches!(instrs[index], Code::Instruction { .. })
                     {
@@ -1598,6 +1680,8 @@ pub fn create_module_from_program<'a>(
             }
         });
 
+    assert!(added_timing);
+
     // Add new main function to act as a entry point to the function.
     // Sets up arguments for a _main call
     // and always returns zero
@@ -1668,25 +1752,6 @@ pub fn create_module_from_program<'a>(
             builder.build_store(ptr, arg).unwrap();
         });
 
-        let ticks_start_name = fresh.fresh_var();
-        #[cfg(target_arch = "x86_64")]
-        let get_ticks_start = "_bril_get_ticks_start";
-        #[cfg(target_arch = "aarch64")]
-        let get_ticks_start = "_bril_get_ticks";
-        let ticks_start = builder
-            .build_call(
-                runtime_module.get_function(get_ticks_start).unwrap(),
-                &[],
-                &ticks_start_name,
-            )
-            .unwrap()
-            .try_as_basic_value()
-            .unwrap_left();
-        // make it always inline get_ticks_start
-        let func = runtime_module.get_function(get_ticks_start).unwrap();
-        func.remove_enum_attribute(AttributeLoc::Function, 28);
-        func.add_attribute(AttributeLoc::Function, context.create_enum_attribute(3, 1));
-
         build_effect_op(
             context,
             &builder,
@@ -1709,44 +1774,6 @@ pub fn create_module_from_program<'a>(
                 .map(|Argument { name, .. }| name.clone())
                 .collect::<Vec<String>>(),
         );
-
-        let ticks_end_name = fresh.fresh_var();
-        #[cfg(target_arch = "x86_64")]
-        let get_ticks_end = "_bril_get_ticks_end";
-        #[cfg(target_arch = "aarch64")]
-        let get_ticks_end = "_bril_get_ticks";
-        let func = runtime_module.get_function(get_ticks_end).unwrap();
-        // always inline get_ticks_end
-        func.remove_enum_attribute(AttributeLoc::Function, 28);
-        func.add_attribute(AttributeLoc::Function, context.create_enum_attribute(3, 1));
-
-        let ticks_end = builder
-            .build_call(
-                runtime_module.get_function(get_ticks_end).unwrap(),
-                &[],
-                &ticks_end_name,
-            )
-            .unwrap()
-            .try_as_basic_value()
-            .unwrap_left();
-
-        // print out the different between the ticks
-        let ticks_diff = fresh.fresh_var();
-        let diff_val = builder
-            .build_int_sub::<IntValue>(
-                ticks_end.try_into().unwrap(),
-                ticks_start.try_into().unwrap(),
-                &ticks_diff,
-            )
-            .unwrap();
-
-        // use bril_print_unsiged_int to print out the difference
-        let print_ticks = runtime_module
-            .get_function("_bril_eprintln_unsigned_int")
-            .unwrap();
-        builder
-            .build_call(print_ticks, &[diff_val.into()], "print_ticks")
-            .unwrap();
     }
     builder
         .build_return(Some(&context.i32_type().const_int(0, true)))


### PR DESCRIPTION
This PR is a hack that adds timing during compilation. It expects benchmarks to print a single time, right before exiting.