### PR TITLE
Abs, Min, and Max using LLVM intrinsics

### DIFF
--- a/bril-rs/brillvm/Cargo.toml
+++ b/bril-rs/brillvm/Cargo.toml
@@ -21,7 +21,7 @@ inkwell = { git = "https://github.com/TheDan64/inkwell.git", features = [
     "llvm18-0",
 ], rev = "6c0fb56b3554e939f9ca61b465043d6a84fb7b95" }
 
-bril-rs = { git = "https://github.com/uwplse/bril", features = ["float", "ssa", "memory"] }
+bril-rs = { git = "https://github.com/uwplse/bril", branch="main", features = ["float", "ssa", "memory"] }
 
 
 # Need to set a default `main` to build `rt` bin

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -787,17 +787,57 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
                 })
                 .unzip();
             let mut code: Vec<Code> = vec_code.into_iter().flatten().collect();
-            if f == "drop" {
-                code.push(Code::Instruction(Instruction::Effect {
-                    args: vars,
-                    funcs: Vec::new(),
-                    labels: Vec::new(),
-                    op: EffectOps::Free,
-                    pos,
-                }));
-                (None, code)
-            } else {
-                match state.get_ret_type_for_func(&f) {
+            match f.as_str() {
+                "drop" => {
+                    code.push(Code::Instruction(Instruction::Effect {
+                        args: vars,
+                        funcs: Vec::new(),
+                        labels: Vec::new(),
+                        op: EffectOps::Free,
+                        pos,
+                    }));
+                    (None, code)
+                }
+                "abs" => {
+                    let dest = state.fresh_var(Type::Int);
+                    code.push(Code::Instruction(Instruction::Value {
+                        args: vars,
+                        dest: dest.clone(),
+                        funcs: Vec::new(),
+                        labels: Vec::new(),
+                        op: ValueOps::Abs,
+                        pos,
+                        op_type: Type::Int,
+                    }));
+                    (Some(dest), code)
+                }
+                "min" => {
+                    let dest = state.fresh_var(Type::Int);
+                    code.push(Code::Instruction(Instruction::Value {
+                        args: vars,
+                        dest: dest.clone(),
+                        funcs: Vec::new(),
+                        labels: Vec::new(),
+                        op: ValueOps::Smin,
+                        pos,
+                        op_type: Type::Int,
+                    }));
+                    (Some(dest), code)
+                }
+                "max" => {
+                    let dest = state.fresh_var(Type::Int);
+                    code.push(Code::Instruction(Instruction::Value {
+                        args: vars,
+                        dest: dest.clone(),
+                        funcs: Vec::new(),
+                        labels: Vec::new(),
+                        op: ValueOps::Smax,
+                        pos,
+                        op_type: Type::Int,
+                    }));
+                    (Some(dest), code)
+                }
+                _ => match state.get_ret_type_for_func(&f) {
                     None => {
                         code.push(Code::Instruction(Instruction::Effect {
                             args: vars,
@@ -821,7 +861,7 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
                         }));
                         (Some(dest), code)
                     }
-                }
+                },
             }
         }
         Expr::Cast(ExprCast {


### PR DESCRIPTION
follow up to #12 

also fixes min and max to correctly use the LLVM intrinsic instead of implementing logic using `select`.